### PR TITLE
Feature to add Windows firewall logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,11 @@ end
 
 - `redirect_port`: redirected port for rules with command `:redirect`
 
-- `logging`: may be added to enable logging for a particular rule. valid values are: `:connections`, `:packets`. In the ufw provider, `:connections` logs new connections while `:packets` logs all packets.
+- `logging`: may be added to enable logging for a particular rule (on Linux platforms) / system-wide (on Windows platform). valid values are:
+  - On Linux platforms:
+    - `:connections`, `:packets`. In the ufw provider, `:connections` logs new connections while `:packets` logs all packets.
+  - On Windows platforms:
+    - `:allowedconnections`, `:droppedconnections`. `:droppedconnections` will log only rejected / dropped connection requests, while `:allowedconnections` will log all new connections established
 
 #### Examples
 

--- a/libraries/provider_firewall_windows.rb
+++ b/libraries/provider_firewall_windows.rb
@@ -57,6 +57,13 @@ class Chef
         end
       end
 
+      unless new_resource.rules['windows'].key?('set currentprofile logging droppedconnections enable')
+        new_resource.rules['windows']['set currentprofile logging droppedconnections disable'] = 0
+      end
+      unless new_resource.rules['windows'].key?('set currentprofile logging allowedconnections enable')
+        new_resource.rules['windows']['set currentprofile logging allowedconnections disable'] = 0
+      end
+
       # ensure a file resource exists with the current rules
       begin
         windows_file = run_context.resource_collection.find(file: windows_rules_filename)

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -20,7 +20,12 @@ class Chef
       }
              )
     attribute(:direction, kind_of: Symbol, equal_to: [:in, :out, :pre, :post], default: :in)
-    attribute(:logging, kind_of: Symbol, equal_to: [:connections, :packets])
+
+    if Chef::Platform.windows?
+      attribute(:logging, kind_of: Symbol, equal_to: [:allowedconnections, :droppedconnections])
+    else
+      attribute(:logging, kind_of: Symbol, equal_to: [:connections, :packets])
+    end
 
     attribute(:source, callbacks: { 'must be a valid ip address' => ->(ip) { !!IPAddr.new(ip) } })
     attribute(:source_port, kind_of: [Integer, Array, Range]) # source port

--- a/test/fixtures/cookbooks/firewall-test/recipes/windows.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/windows.rb
@@ -48,3 +48,8 @@ firewall_rule 'Incomingt_Rule_5' do
   position 6
   protocol :tcp
 end
+
+firewall_rule 'logging' do
+  command :log
+  logging :droppedconnections
+end

--- a/test/integration/windows/serverspec/windows_spec.rb
+++ b/test/integration/windows/serverspec/windows_spec.rb
@@ -8,7 +8,9 @@ expected_rules = [
   %r{firewall add rule name="Incoming_Rule_3" description="Incoming_Rule_3" dir=in service=any protocol=tcp localip=any localport=5986 interfacetype=any remoteip=any remoteport=any action=allow},
   %r{firewall add rule name="Incomingt_Rule_4" description="Incomingt_Rule_4" dir=in service=any protocol=tcp localip=any localport=3389 interfacetype=any remoteip=any remoteport=any action=allow},
   %r{firewall add rule name="Incomingt_Rule_5" description="Incomingt_Rule_5" dir=in service=any protocol=tcp localip=any localport=80 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="allow world to winrm" description="allow world to winrm" dir=in service=any protocol=tcp localip=any localport=5989 interfacetype=any remoteip=any remoteport=any action=allow}
+  %r{firewall add rule name="allow world to winrm" description="allow world to winrm" dir=in service=any protocol=tcp localip=any localport=5989 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{set currentprofile logging allowedconnections disable},
+  %r{set currentprofile logging droppedconnections enable}
 ]
 
 describe file("#{ENV['HOME']}/windows-chef.rules"), if: windows? do
@@ -19,4 +21,12 @@ end
 
 describe command('netsh advfirewall firewall show rule name=all'), if: windows? do
   its(:stdout) { should count_occurences('Rule Name:', 7) }
+end
+
+describe command('netsh advfirewall show currentprofile logging | findstr LogDroppedConnections'), if: windows? do
+  its(:stdout) { should match('Enable') }
+end
+
+describe command('netsh advfirewall show currentprofile logging | findstr LogAllowedConnections'), if: windows? do
+  its(:stdout) { should match('Disable') }
 end


### PR DESCRIPTION
Feature to define logging on Windows firewall
- Handle :log command for Windows firewall
- Define special :log property on Windows platform: log allowed connections log dropped connections
- Handle logging configuration based on provided attributes and keep the rest as default disabled (default Windows settings)

Integration tests and documentation update included.
