### PR TITLE
If service is not provided while registering firewall rule, it should…

### DIFF
--- a/libraries/helpers_windows.rb
+++ b/libraries/helpers_windows.rb
@@ -73,7 +73,7 @@ module FirewallCookbook
           parameters['dir'] = new_resource.direction
 
           new_resource.program && parameters['program'] = new_resource.program
-          parameters['service'] = new_resource.service ? new_resource.service : 'any'
+          new_resource.service && parameters['service'] = new_resource.service
           parameters['protocol'] = new_resource.protocol
 
           if new_resource.direction.to_sym == :out


### PR DESCRIPTION
… be left empty so any service can use this rule
